### PR TITLE
Set up CI with Azure Pipelines Closes #45

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,0 @@
-build-job:
-  stage: build
-  script:
-    - echo "Hello, $GITLAB_USER_LOGIN!"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: python
-python: # La 3.10 se comprueba en nuestro Docker
-  - "3.7"
-  - "3.8"
-  - "3.9"
-# Instalamos dependencias
-install:
-  - pip install poetry

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,25 @@
+pool:
+  vmImage: ubuntu-latest
+
+variables:
+  GOBIN:  '$(GOPATH)/bin' # Go binaries path
+  GOROOT: '/usr/local/go1.19' # Go installation path
+  GOPATH: '$(system.defaultWorkingDirectory)/gopath' # Go workspace path
+  modulePath: '$(GOPATH)/src/github.com/$(build.repository.name)' # Path to the module's code
+
+steps: 
+- task: GoTool@0
+  inputs:
+    version: '1.19.3'
+
+- task: Go@0
+  inputs:
+    command: 'get'
+    arguments: '-t cotan/types/models'
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
+
+- task: Go@0
+  inputs:
+    command: 'test'
+    arguments: './...'
+    workingDirectory: '$(System.DefaultWorkingDirectory)'


### PR DESCRIPTION
Este PR es creado por Azure Pipelines y nos permite testear Go con la versión 1.19.3

Se elimina la configuración de Travis y Gitlab CI por no tener cuota gratuita.